### PR TITLE
[i18n] Add i18n to Elements

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/elements/strings.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/elements/strings.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const ElementStrings: {
+  [name: string]: {
+    displayName: string;
+    help: string;
+  };
+} = {
+  areaChart: {
+    displayName: i18n.translate('xpack.canvas.elements.areaChartDisplayName', {
+      defaultMessage: 'Area chart',
+    }),
+    help: i18n.translate('xpack.canvas.elements.areaChartHelpText', {
+      defaultMessage: 'A line chart with a filled body',
+    }),
+  },
+  bubbleChart: {
+    displayName: i18n.translate('xpack.canvas.elements.bubbleChartDisplayName', {
+      defaultMessage: 'Bubble chart',
+    }),
+    help: i18n.translate('xpack.canvas.elements.bubbleChartHelpText', {
+      defaultMessage: 'A customizable bubble chart',
+    }),
+  },
+  debug: {
+    displayName: i18n.translate('xpack.canvas.elements.debugDisplayName', {
+      defaultMessage: 'Debug',
+    }),
+    help: i18n.translate('xpack.canvas.elements.debugHelpText', {
+      defaultMessage: 'Just dumps the configuration of the element',
+    }),
+  },
+  donut: {
+    displayName: i18n.translate('xpack.canvas.elements.donutChartDisplayName', {
+      defaultMessage: 'Donut chart',
+    }),
+    help: i18n.translate('xpack.canvas.elements.donutChartHelpText', {
+      defaultMessage: 'A customizable donut chart',
+    }),
+  },
+  dropdownFilter: {
+    displayName: i18n.translate('xpack.canvas.elements.dropdownFilterDisplayName', {
+      defaultMessage: 'Dropdown Filter',
+    }),
+    help: i18n.translate('xpack.canvas.elements.dropdownFilterHelpText', {
+      defaultMessage: 'A dropdown from which you can select values for an "exactly" filter',
+    }),
+  },
+  horizontalBarChart: {
+    displayName: i18n.translate('xpack.canvas.elements.horizontalBarChartDisplayName', {
+      defaultMessage: 'Horizontal Bar chart',
+    }),
+    help: i18n.translate('xpack.canvas.elements.horizontalBarChartHelpText', {
+      defaultMessage: 'A customizable horizontal bar chart',
+    }),
+  },
+  horizontalProgressBar: {
+    displayName: i18n.translate('xpack.canvas.elements.horizontalProgressBarDisplayName', {
+      defaultMessage: 'Horizontal Progress Bar',
+    }),
+    help: i18n.translate('xpack.canvas.elements.horizontalProgressBarHelpText', {
+      defaultMessage: 'Displays progress as a portion of a horizontal bar',
+    }),
+  },
+  horizontalProgressPill: {
+    displayName: i18n.translate('xpack.canvas.elements.horizontalProgressPillDisplayName', {
+      defaultMessage: 'Horizontal Progress Pill',
+    }),
+    help: i18n.translate('xpack.canvas.elements.horizontalProgressPillHelpText', {
+      defaultMessage: 'Displays progress as a portion of a horizontal pill',
+    }),
+  },
+  image: {
+    displayName: i18n.translate('xpack.canvas.elements.imageDisplayName', {
+      defaultMessage: 'Image',
+    }),
+    help: i18n.translate('xpack.canvas.elements.imageHelpText', {
+      defaultMessage: 'A static image',
+    }),
+  },
+  lineChart: {
+    displayName: i18n.translate('xpack.canvas.elements.lineChartDisplayName', {
+      defaultMessage: 'Line chart',
+    }),
+    help: i18n.translate('xpack.canvas.elements.lineChartHelpText', {
+      defaultMessage: 'A customizable line chart',
+    }),
+  },
+  markdown: {
+    displayName: i18n.translate('xpack.canvas.elements.markdownDisplayName', {
+      defaultMessage: 'Markdown',
+    }),
+    help: i18n.translate('xpack.canvas.elements.markdownHelpText', {
+      defaultMessage: 'Markup from Markdown',
+    }),
+  },
+  metric: {
+    displayName: i18n.translate('xpack.canvas.elements.metricDisplayName', {
+      defaultMessage: 'Metric',
+    }),
+    help: i18n.translate('xpack.canvas.elements.metricHelpText', {
+      defaultMessage: 'A number with a label',
+    }),
+  },
+  pie: {
+    displayName: i18n.translate('xpack.canvas.elements.pieDisplayName', {
+      defaultMessage: 'Pie chart',
+    }),
+    help: i18n.translate('xpack.canvas.elements.pieHelpText', {
+      defaultMessage: 'Pie chart',
+    }),
+  },
+  plot: {
+    displayName: i18n.translate('xpack.canvas.elements.plotDisplayName', {
+      defaultMessage: 'Coordinate plot',
+    }),
+    help: i18n.translate('xpack.canvas.elements.plotHelpText', {
+      defaultMessage: 'Mixed line, bar or dot charts',
+    }),
+  },
+  progressGauge: {
+    displayName: i18n.translate('xpack.canvas.elements.progressGaugeDisplayName', {
+      defaultMessage: 'Progress Gauge',
+    }),
+    help: i18n.translate('xpack.canvas.elements.progressGaugeHelpText', {
+      defaultMessage: 'Displays progress as a portion of a gauge',
+    }),
+  },
+  progressSemicircle: {
+    displayName: i18n.translate('xpack.canvas.elements.progressSemicircleDisplayName', {
+      defaultMessage: 'Progress Semicircle',
+    }),
+    help: i18n.translate('xpack.canvas.elements.progressSemicircleHelpText', {
+      defaultMessage: 'Displays progress as a portion of a semicircle',
+    }),
+  },
+  progressWheel: {
+    displayName: i18n.translate('xpack.canvas.elements.progressWheelDisplayName', {
+      defaultMessage: 'Progress Wheel',
+    }),
+    help: i18n.translate('xpack.canvas.elements.progressWheelHelpText', {
+      defaultMessage: 'Displays progress as a portion of a wheel',
+    }),
+  },
+  repeatImage: {
+    displayName: i18n.translate('xpack.canvas.elements.repeatImageDisplayName', {
+      defaultMessage: 'Image repeat',
+    }),
+    help: i18n.translate('xpack.canvas.elements.repeatImageHelpText', {
+      defaultMessage: 'Repeats an image N times',
+    }),
+  },
+  revealImage: {
+    displayName: i18n.translate('xpack.canvas.elements.revealImageDisplayName', {
+      defaultMessage: 'Image reveal',
+    }),
+    help: i18n.translate('xpack.canvas.elements.revealImageHelpText', {
+      defaultMessage: 'Reveals a percentage of an image',
+    }),
+  },
+  shape: {
+    displayName: i18n.translate('xpack.canvas.elements.shapeDisplayName', {
+      defaultMessage: 'Shape',
+    }),
+    help: i18n.translate('xpack.canvas.elements.shapeHelpText', {
+      defaultMessage: 'A customizable shape',
+    }),
+  },
+  table: {
+    displayName: i18n.translate('xpack.canvas.elements.tableDisplayName', {
+      defaultMessage: 'Data table',
+    }),
+    help: i18n.translate('xpack.canvas.elements.tableHelpText', {
+      defaultMessage: 'A scrollable grid for displaying data in a tabular format',
+    }),
+  },
+  tiltedPie: {
+    displayName: i18n.translate('xpack.canvas.elements.tiltedPieDisplayName', {
+      defaultMessage: 'Tilted pie chart',
+    }),
+    help: i18n.translate('xpack.canvas.elements.tiltedPieHelpText', {
+      defaultMessage: 'A customizable tilted pie chart',
+    }),
+  },
+  timeFilter: {
+    displayName: i18n.translate('xpack.canvas.elements.timeFilterDisplayName', {
+      defaultMessage: 'Time filter',
+    }),
+    help: i18n.translate('xpack.canvas.elements.timeFilterHelpText', {
+      defaultMessage: 'Set a time window',
+    }),
+  },
+  verticalBarChart: {
+    displayName: i18n.translate('xpack.canvas.elements.verticalBarChartDisplayName', {
+      defaultMessage: 'Vertical bar chart',
+    }),
+    help: i18n.translate('xpack.canvas.elements.verticalBarChartHelpText', {
+      defaultMessage: 'A customizable vertical bar chart',
+    }),
+  },
+  verticalProgressBar: {
+    displayName: i18n.translate('xpack.canvas.elements.verticalProgressBarDisplayName', {
+      defaultMessage: 'Vertical Progress Bar',
+    }),
+    help: i18n.translate('xpack.canvas.elements.verticalProgressBarHelpText', {
+      defaultMessage: 'Displays progress as a portion of a vertical bar',
+    }),
+  },
+  verticalProgressPill: {
+    displayName: i18n.translate('xpack.canvas.elements.verticalProgressPillDisplayName', {
+      defaultMessage: 'Vertical Progress Pill',
+    }),
+    help: i18n.translate('xpack.canvas.elements.verticalProgressPillHelpText', {
+      defaultMessage: 'Displays progress as a portion of a vertical pill',
+    }),
+  },
+};

--- a/x-pack/plugins/canvas/public/lib/element.ts
+++ b/x-pack/plugins/canvas/public/lib/element.ts
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
+import { ElementStrings } from './../../canvas_plugin_src/elements/strings';
 import defaultHeader from './default_header.png';
 
 export class Element {
@@ -24,13 +25,14 @@ export class Element {
   public height?: number;
 
   constructor(config: CanvasElementConfig) {
-    const { name, image, displayName, expression, filter, width, height } = config;
+    const { name, image, displayName, expression, filter, help, width, height } = config;
+    const elementStrings = ElementStrings[name];
     this.name = name;
-    this.displayName = displayName || name;
+    this.displayName = (elementStrings && elementStrings.displayName) || displayName || name;
     this.image = image || defaultHeader;
-    this.help = config.help || '';
+    this.help = (elementStrings && elementStrings.help) || help || '';
 
-    if (!config.expression) {
+    if (!expression) {
       throw new Error('Element types must have a default expression');
     }
 


### PR DESCRIPTION
# [i18n] Add i18n to Elements

## Summary

This diff reconstitutes #23755 as a more concise, clean integration of displayName and help.  These fields are now automatically applied from a strings registry.

I attempted to add a unit test, but couldn't get Mocha to understand how to parse the included `png` files.  If someone could help me figure out how to get it working, I'd love to add it:

```
import expect from 'expect.js';
import { elementSpecs } from '../';
import { ElementStrings } from '../strings';

describe('ElementStrings', () => {
  const elementNames = elementSpecs.map(spec => spec.name);
  const stringKeys = Object.keys(ElementStrings);

  elementNames.forEach(name => expect(stringKeys).contain(name));
  stringKeys.forEach(key => {
    const strings = ElementStrings[key];
    expect(strings).property('displayName');
    expect(strings).property('help');
    const { displayName } = strings;
    expect(elementNames).contain(displayName);
  });
});
```

### For maintainers

- [x] This was checked for breaking API changes and was labeled appropriately