### PR TITLE
Use EUI SASS vars, copy change to callout message

### DIFF
--- a/x-pack/legacy/plugins/canvas/external_runtime/components/footer/footer.module.scss
+++ b/x-pack/legacy/plugins/canvas/external_runtime/components/footer/footer.module.scss
@@ -1,3 +1,6 @@
+@import '@elastic/eui/src/global_styling/variables/_size.scss';
+@import '@elastic/eui/src/global_styling/variables/_colors.scss';
+
 :global .kbnCanvas :local .root .bar {
   position: absolute;
 }
@@ -8,7 +11,7 @@
 
 :global .kbnCanvas :local .bar {
   transition: bottom 0.25s;
-  padding: 12px;
+  padding: $euiSizeM;
 }
 
 :global .kbnCanvas :local .title {
@@ -17,4 +20,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   flex-grow: 1;
+}
+
+:global .kbnCanvas .euiIcon__fillNegative {
+  fill: $euiColorGhost !important;
 }

--- a/x-pack/legacy/plugins/canvas/external_runtime/components/footer/page_preview.module.scss
+++ b/x-pack/legacy/plugins/canvas/external_runtime/components/footer/page_preview.module.scss
@@ -1,5 +1,7 @@
+@import '@elastic/eui/src/global_styling/variables/_size.scss';
+
 :global .kbnCanvas :local .root {
-  margin: 0 8px;
+  margin: 0 $euiSizeS;
   cursor: pointer;
 }
 

--- a/x-pack/legacy/plugins/canvas/external_runtime/components/footer/scrubber.module.scss
+++ b/x-pack/legacy/plugins/canvas/external_runtime/components/footer/scrubber.module.scss
@@ -3,12 +3,12 @@
 @import '@elastic/eui/src/global_styling/mixins/_helpers.scss';
 
 :global .kbnCanvas :local .root {
-  background: #fff;
+  background: $euiColorGhost;
   position: absolute;
   bottom: -172px;
   left: 0;
   right: 0;
-  padding: 8px 0 48px 0;
+  padding: $euiSizeS 0 ($euiSizeL * 2) 0;
   transition: bottom 0.25s;
   height: 172px;
 }

--- a/x-pack/legacy/plugins/canvas/external_runtime/components/footer/title.tsx
+++ b/x-pack/legacy/plugins/canvas/external_runtime/components/footer/title.tsx
@@ -21,7 +21,7 @@ export const Title = () => {
   return (
     <EuiFlexGroup gutterSize="s" justifyContent="flexStart" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiIcon type="logoKibana" size="l" />
+        <EuiIcon type="logoKibana" size="m" />
       </EuiFlexItem>
       <EuiFlexItem grow={false} style={{ minWidth: 0 }}>
         <EuiText color="ghost" size="s">

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/workpad_export/flyout/external_embed_flyout.scss
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/workpad_export/flyout/external_embed_flyout.scss
@@ -1,3 +1,0 @@
-.canvasWorkpadExport__embedFlyout {
-  min-width: 800px;
-}

--- a/x-pack/legacy/plugins/canvas/public/components/workpad_header/workpad_export/flyout/external_embed_flyout.tsx
+++ b/x-pack/legacy/plugins/canvas/public/components/workpad_header/workpad_export/flyout/external_embed_flyout.tsx
@@ -152,7 +152,7 @@ const HTML = `<!-- Include Runtime -->
 </script>`;
 
 export const ExternalEmbedFlyout = ({ onCopy, onExport, onClose }: Props) => (
-  <EuiFlyout onClose={() => onClose('embed')} className="canvasWorkpadExport__embedFlyout" size="s">
+  <EuiFlyout onClose={() => onClose('embed')} maxWidth>
     <EuiFlyoutHeader hasBorder>
       <EuiTitle size="m">
         <h2 id="flyoutTitle">Embed on a website</h2>
@@ -170,14 +170,14 @@ export const ExternalEmbedFlyout = ({ onCopy, onExport, onClose }: Props) => (
         size="s"
         title={
           <div>
-            Alternatively, you can{' '}
+            To try embedding, you can{' '}
             <EuiLink
               style={{ textDecoration: 'underline' }}
               onClick={() => {
                 onExport('zip');
               }}
             >
-              download a ZIP file
+              download an example ZIP file
             </EuiLink>{' '}
             containing this workpad, the Canvas runtime, and a sample HTML file.
           </div>


### PR DESCRIPTION
## Summary

- SASS changes to use EUI variables for color and size
- Remove width on flyout (instead handle via `EuiFlyout`'s `maxWidth` prop)
- Tweak the wording in the callout to emphasize that this is a quick way to try things out (aka a full example)
