### PR TITLE
add new sibling class to kbnBody for project-style layout

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/chrome_service.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/chrome_service.tsx
@@ -138,6 +138,9 @@ export class ChromeService {
       map(([headerBanner, isVisible]) => {
         return [
           'kbnBody',
+          chromeStyle$.getValue() === 'classic'
+            ? 'kbnBody--classicLayout'
+            : 'kbnBody--projectLayout',
           headerBanner ? 'kbnBody--hasHeaderBanner' : 'kbnBody--noHeaderBanner',
           isVisible ? 'kbnBody--chromeVisible' : 'kbnBody--chromeHidden',
           getKbnVersionClass(),

--- a/src/core/public/_variables.scss
+++ b/src/core/public/_variables.scss
@@ -3,6 +3,6 @@
 // height of the header banner
 $kbnHeaderBannerHeight: $euiSizeXL; // This value is also declared in `/x-pack/plugins/canvas/common/lib/constants.ts`
 // total height of the header (when the banner is *not* present)
-$kbnHeaderOffset: $euiHeaderHeightCompensation; // <- TODO: this change is a hack for demo purposes.
+$kbnHeaderOffset: $euiHeaderHeightCompensation * 2;
 // total height of the header when the banner is present
 $kbnHeaderOffsetWithBanner: $kbnHeaderOffset + $kbnHeaderBannerHeight;

--- a/src/core/public/styles/rendering/_base.scss
+++ b/src/core/public/styles/rendering/_base.scss
@@ -75,6 +75,9 @@
   &.kbnBody--chromeHidden {
     @include kbnAffordForHeader(0);
   }
+  &.kbnBody--projectLayout {
+    @include kbnAffordForHeader($euiHeaderHeightCompensation);
+  }
   &.kbnBody--chromeHidden.kbnBody--hasHeaderBanner {
     @include kbnAffordForHeader($kbnHeaderBannerHeight);
   }


### PR DESCRIPTION
## Summary

This PR undoes the hack to fix layout style for project types, with CSS that doesn't impact everything.