### PR TITLE
[poc]: serverless_search

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -549,6 +549,7 @@ packages/kbn-server-http-tools @elastic/kibana-core
 packages/kbn-server-route-repository @elastic/apm-ui
 x-pack/plugins/serverless @elastic/appex-sharedux
 x-pack/plugins/serverless_observability @elastic/appex-sharedux
+x-pack/plugins/serverless_search @elastic/appex-sharedux @elastic/enterprise-search-frontend
 x-pack/plugins/serverless_security @elastic/appex-sharedux
 test/plugin_functional/plugins/session_notifications @elastic/kibana-core
 x-pack/plugins/session_view @elastic/awp-viz

--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -1,0 +1,10 @@
+xpack.apm.enabled: false
+xpack.canvas.enabled: false
+xpack.reporting.enabled: false
+xpack.uptime.enabled: false
+xpack.watcher.enabled: false
+
+enterpriseSearch.enabled: true
+xpack.serverless.search.enabled: true
+
+uiSettings.overrides.defaultRoute: /app/enterprise_search/content/search_indices

--- a/package.json
+++ b/package.json
@@ -551,6 +551,7 @@
     "@kbn/server-route-repository": "link:packages/kbn-server-route-repository",
     "@kbn/serverless": "link:x-pack/plugins/serverless",
     "@kbn/serverless-observability": "link:x-pack/plugins/serverless_observability",
+    "@kbn/serverless-search": "link:x-pack/plugins/serverless_search",
     "@kbn/serverless-security": "link:x-pack/plugins/serverless_security",
     "@kbn/session-notifications-plugin": "link:test/plugin_functional/plugins/session_notifications",
     "@kbn/session-view-plugin": "link:x-pack/plugins/session_view",

--- a/src/plugins/management/public/components/management_app/management_app.tsx
+++ b/src/plugins/management/public/components/management_app/management_app.tsx
@@ -34,6 +34,7 @@ export interface ManagementAppDependencies {
   sections: SectionsServiceStart;
   kibanaVersion: string;
   setBreadcrumbs: (newBreadcrumbs: ChromeBreadcrumb[]) => void;
+  getIsSidebarEnabled: () => boolean;
 }
 
 export const ManagementApp = ({ dependencies, history, theme$ }: ManagementAppProps) => {
@@ -75,18 +76,21 @@ export const ManagementApp = ({ dependencies, history, theme$ }: ManagementAppPr
     return null;
   }
 
-  const solution: KibanaPageTemplateProps['solutionNav'] = {
-    name: i18n.translate('management.nav.label', {
-      defaultMessage: 'Management',
-    }),
-    icon: 'managementApp',
-    'data-test-subj': 'mgtSideBarNav',
-    items: managementSidebarNav({
-      selectedId,
-      sections,
-      history,
-    }),
-  };
+  const solution: KibanaPageTemplateProps['solutionNav'] | undefined =
+    dependencies.getIsSidebarEnabled()
+      ? {
+          name: i18n.translate('management.nav.label', {
+            defaultMessage: 'Management',
+          }),
+          icon: 'managementApp',
+          'data-test-subj': 'mgtSideBarNav',
+          items: managementSidebarNav({
+            selectedId,
+            sections,
+            history,
+          }),
+        }
+      : undefined;
 
   return (
     <I18nProvider>

--- a/src/plugins/management/public/plugin.ts
+++ b/src/plugins/management/public/plugin.ts
@@ -71,6 +71,8 @@ export class ManagementPlugin
 
   private hasAnyEnabledApps = true;
 
+  private isSidebarEnabled = true;
+
   constructor(private initializerContext: PluginInitializerContext) {}
 
   public setup(core: CoreSetup, { home, share }: ManagementSetupDependencies) {
@@ -93,6 +95,7 @@ export class ManagementPlugin
         visible: () => this.hasAnyEnabledApps,
       });
     }
+    const managementPlugin = this;
 
     core.application.register({
       id: MANAGEMENT_APP_ID,
@@ -111,6 +114,7 @@ export class ManagementPlugin
           sections: getSectionsServiceStartPrivate(),
           kibanaVersion,
           setBreadcrumbs: coreStart.chrome.setBreadcrumbs,
+          getIsSidebarEnabled: () => managementPlugin.isSidebarEnabled,
         });
       },
     });
@@ -118,6 +122,9 @@ export class ManagementPlugin
     return {
       sections: this.managementSections.setup(),
       locator,
+      setIsSidebarEnabled: (enabled: boolean) => {
+        this.isSidebarEnabled = enabled;
+      },
     };
   }
 

--- a/src/plugins/management/public/types.ts
+++ b/src/plugins/management/public/types.ts
@@ -16,6 +16,7 @@ import type { ManagementAppLocatorParams } from '../common/locator';
 export interface ManagementSetup {
   sections: SectionsServiceSetup;
   locator: LocatorPublic<ManagementAppLocatorParams>;
+  setIsSidebarEnabled: (enabled: boolean) => void;
 }
 
 export interface DefinedSections {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1092,6 +1092,8 @@
       "@kbn/serverless/*": ["x-pack/plugins/serverless/*"],
       "@kbn/serverless-observability": ["x-pack/plugins/serverless_observability"],
       "@kbn/serverless-observability/*": ["x-pack/plugins/serverless_observability/*"],
+      "@kbn/serverless-search": ["x-pack/plugins/serverless_search"],
+      "@kbn/serverless-search/*": ["x-pack/plugins/serverless_search/*"],
       "@kbn/serverless-security": ["x-pack/plugins/serverless_security"],
       "@kbn/serverless-security/*": ["x-pack/plugins/serverless_security/*"],
       "@kbn/session-notifications-plugin": ["test/plugin_functional/plugins/session_notifications"],

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/header_actions/header_actions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/header_actions/header_actions.tsx
@@ -15,15 +15,22 @@ import { SearchEnginesPopover } from './search_engines_popover';
 import { SyncsContextMenu } from './syncs_context_menu';
 
 // Used to populate rightSideItems of an EuiPageTemplate, which is rendered right-to-left
-export const getHeaderActions = (indexData?: ElasticsearchIndexWithIngestion) => {
+export const getHeaderActions = (
+  indexData?: ElasticsearchIndexWithIngestion,
+  hasAppSearchAccess?: boolean
+) => {
   const ingestionMethod = getIngestionMethod(indexData);
   return [
     ...(isCrawlerIndex(indexData) && indexData.connector ? [<CrawlerStatusIndicator />] : []),
     ...(isConnectorIndex(indexData) ? [<SyncsContextMenu />] : []),
-    <SearchEnginesPopover
-      indexName={indexData?.name}
-      ingestionMethod={ingestionMethod}
-      isHiddenIndex={indexData?.hidden}
-    />,
+    ...(hasAppSearchAccess || hasAppSearchAccess === undefined
+      ? [
+          <SearchEnginesPopover
+            indexName={indexData?.name}
+            ingestionMethod={ingestionMethod}
+            isHiddenIndex={indexData?.hidden}
+          />,
+        ]
+      : []),
   ];
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/search_index.tsx
@@ -75,7 +75,10 @@ export const SearchIndex: React.FC = () => {
    * This needs to be checked for any of the 3 registered search guideIds
    * Putting it here guarantees that if a user is viewing an index with data, it'll be marked as complete
    */
-  const { guidedOnboarding } = useValues(KibanaLogic);
+  const {
+    guidedOnboarding,
+    productAccess: { hasAppSearchAccess },
+  } = useValues(KibanaLogic);
   const isAppGuideActive = useObservable(
     guidedOnboarding.guidedOnboardingApi!.isGuideStepActive$('appSearch', 'add_data')
   );
@@ -222,7 +225,7 @@ export const SearchIndex: React.FC = () => {
       isLoading={isInitialLoading}
       pageHeader={{
         pageTitle: indexName,
-        rightSideItems: getHeaderActions(index),
+        rightSideItems: getHeaderActions(index, hasAppSearchAccess),
       }}
     >
       {isCrawlerIndex(index) && !index.connector ? (

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -36,7 +36,17 @@ import { mountLicensingLogic } from './shared/licensing';
 
 export const renderApp = (
   App: React.FC<InitialAppData>,
-  { params, core, plugins }: { params: AppMountParameters; core: CoreStart; plugins: PluginsStart },
+  {
+    params,
+    core,
+    plugins,
+    getIsSidebarEnabled,
+  }: {
+    params: AppMountParameters;
+    core: CoreStart;
+    plugins: PluginsStart;
+    getIsSidebarEnabled: () => boolean;
+  },
   { config, data }: { config: ClientConfigType; data: ClientData }
 ) => {
   const { publicUrl, errorConnectingMessage, ...initialData } = data;
@@ -64,6 +74,7 @@ export const renderApp = (
     charts: plugins.charts,
     cloud: plugins.cloud,
     uiSettings: core.uiSettings,
+    getIsSidebarEnabled,
     guidedOnboarding: plugins.guidedOnboarding,
     history: params.history,
     navigateToUrl: core.application.navigateToUrl,

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -40,12 +40,12 @@ export const renderApp = (
     params,
     core,
     plugins,
-    getIsSidebarEnabled,
+    isSidebarEnabled,
   }: {
     params: AppMountParameters;
     core: CoreStart;
     plugins: PluginsStart;
-    getIsSidebarEnabled: () => boolean;
+    isSidebarEnabled: boolean;
   },
   { config, data }: { config: ClientConfigType; data: ClientData }
 ) => {
@@ -74,7 +74,7 @@ export const renderApp = (
     charts: plugins.charts,
     cloud: plugins.cloud,
     uiSettings: core.uiSettings,
-    getIsSidebarEnabled,
+    isSidebarEnabled,
     guidedOnboarding: plugins.guidedOnboarding,
     history: params.history,
     navigateToUrl: core.application.navigateToUrl,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
@@ -33,7 +33,7 @@ interface KibanaLogicProps {
   application: ApplicationStart;
   config: { host?: string };
   productAccess: ProductAccess;
-  getIsSidebarEnabled: () => boolean;
+  isSidebarEnabled: boolean;
   // Kibana core
   capabilities: Capabilities;
   history: ScopedHistory;
@@ -54,7 +54,6 @@ interface KibanaLogicProps {
 export interface KibanaValues extends Omit<KibanaLogicProps, 'cloud'> {
   cloud: Partial<CloudSetup>;
   isCloud: boolean;
-  isSidebarEnabled: boolean;
   navigateToUrl(path: string, options?: CreateHrefOptions): Promise<void>;
 }
 
@@ -66,9 +65,9 @@ export const KibanaLogic = kea<MakeLogicType<KibanaValues>>({
     config: [props.config || {}, {}],
     charts: [props.charts, {}],
     cloud: [props.cloud || {}, {}],
-    getIsSidebarEnabled: [props.getIsSidebarEnabled, {}],
     guidedOnboarding: [props.guidedOnboarding, {}],
     history: [props.history, {}],
+    isSidebarEnabled: [props.isSidebarEnabled, {}],
     navigateToUrl: [
       (url: string, options?: CreateHrefOptions) => {
         const deps = { history: props.history, http: HttpLogic.values.http };
@@ -87,10 +86,6 @@ export const KibanaLogic = kea<MakeLogicType<KibanaValues>>({
   }),
   selectors: ({ selectors }) => ({
     isCloud: [() => [selectors.cloud], (cloud?: Partial<CloudSetup>) => !!cloud?.isCloudEnabled],
-    isSidebarEnabled: [
-      () => [selectors.getIsSidebarEnabled],
-      (getIsSidebarEnabled: () => boolean) => getIsSidebarEnabled(),
-    ],
   }),
 });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
@@ -33,6 +33,7 @@ interface KibanaLogicProps {
   application: ApplicationStart;
   config: { host?: string };
   productAccess: ProductAccess;
+  getIsSidebarEnabled: () => boolean;
   // Kibana core
   capabilities: Capabilities;
   history: ScopedHistory;
@@ -49,9 +50,11 @@ interface KibanaLogicProps {
   // Optional plugins
   cloud?: CloudSetup;
 }
+
 export interface KibanaValues extends Omit<KibanaLogicProps, 'cloud'> {
   cloud: Partial<CloudSetup>;
   isCloud: boolean;
+  isSidebarEnabled: boolean;
   navigateToUrl(path: string, options?: CreateHrefOptions): Promise<void>;
 }
 
@@ -63,6 +66,7 @@ export const KibanaLogic = kea<MakeLogicType<KibanaValues>>({
     config: [props.config || {}, {}],
     charts: [props.charts, {}],
     cloud: [props.cloud || {}, {}],
+    getIsSidebarEnabled: [props.getIsSidebarEnabled, {}],
     guidedOnboarding: [props.guidedOnboarding, {}],
     history: [props.history, {}],
     navigateToUrl: [
@@ -83,6 +87,10 @@ export const KibanaLogic = kea<MakeLogicType<KibanaValues>>({
   }),
   selectors: ({ selectors }) => ({
     isCloud: [() => [selectors.cloud], (cloud?: Partial<CloudSetup>) => !!cloud?.isCloudEnabled],
+    isSidebarEnabled: [
+      () => [selectors.getIsSidebarEnabled],
+      (getIsSidebarEnabled: () => boolean) => getIsSidebarEnabled(),
+    ],
   }),
 });
 

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -30,8 +30,9 @@ import { KibanaLogic } from '../kibana';
 import { generateNavLink } from './nav_link_helpers';
 
 export const useEnterpriseSearchNav = () => {
-  const { productAccess } = useValues(KibanaLogic);
+  const { isSidebarEnabled, productAccess } = useValues(KibanaLogic);
 
+  if (!isSidebarEnabled) return undefined;
   const enginesSectionEnabled = productAccess.hasSearchEnginesAccess;
 
   const navItems: Array<EuiSideNavItemType<unknown>> = [
@@ -243,6 +244,7 @@ export const useEnterpriseSearchNav = () => {
 
 export const useEnterpriseSearchEngineNav = (engineName?: string, isEmptyState?: boolean) => {
   const navItems = useEnterpriseSearchNav();
+  if (!navItems) return undefined;
   if (!engineName) return navItems;
   const searchItem = navItems.find((item) => item.id === 'enginesSearch');
   if (!searchItem || !searchItem.items) return navItems;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
@@ -73,7 +73,11 @@ export const EnterpriseSearchPageTemplateWrapper: React.FC<PageTemplateProps> = 
         ),
       }}
       isEmptyState={isEmptyState && !isLoading}
-      solutionNav={solutionNav ? { icon: 'logoEnterpriseSearch', ...solutionNav } : undefined}
+      solutionNav={
+        solutionNav && solutionNav.items
+          ? { icon: 'logoEnterpriseSearch', ...solutionNav }
+          : undefined
+      }
     >
       {setPageChrome}
       {readOnlyMode && (

--- a/x-pack/plugins/enterprise_search/public/index.ts
+++ b/x-pack/plugins/enterprise_search/public/index.ts
@@ -12,3 +12,5 @@ import { EnterpriseSearchPlugin } from './plugin';
 export const plugin = (initializerContext: PluginInitializerContext) => {
   return new EnterpriseSearchPlugin(initializerContext);
 };
+
+export type { EnterpriseSearchPublicSetup, EnterpriseSearchPublicStart } from './plugin';

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -45,6 +45,9 @@ export interface ClientData extends InitialAppData {
   errorConnectingMessage?: string;
 }
 
+export type EnterpriseSearchPublicSetup = ReturnType<EnterpriseSearchPlugin['setup']>;
+export type EnterpriseSearchPublicStart = ReturnType<EnterpriseSearchPlugin['start']>;
+
 interface PluginsSetup {
   cloud?: CloudSetup;
   home?: HomePublicPluginSetup;
@@ -64,6 +67,7 @@ export class EnterpriseSearchPlugin implements Plugin {
   private config: ClientConfigType;
   private hasInitialized: boolean = false;
   private data: ClientData = {} as ClientData;
+  private isSidebarEnabled: boolean = true;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.config = initializerContext.config.get<ClientConfigType>();
@@ -288,6 +292,14 @@ export class EnterpriseSearchPlugin implements Plugin {
         showOnHomePage: false,
       });
     }
+
+    return {
+      navigation: {
+        setIsSidebarEnabled: (enabled: boolean) => {
+          this.isSidebarEnabled = enabled;
+        },
+      },
+    };
   }
 
   public start(core: CoreStart) {
@@ -312,7 +324,7 @@ export class EnterpriseSearchPlugin implements Plugin {
         : undefined;
     const plugins = { ...pluginsStart, cloud } as PluginsStart;
 
-    return { params, core: coreStart, plugins };
+    return { params, core: coreStart, plugins, getIsSidebarEnabled: () => this.isSidebarEnabled };
   }
 
   private getPluginData() {

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -324,7 +324,7 @@ export class EnterpriseSearchPlugin implements Plugin {
         : undefined;
     const plugins = { ...pluginsStart, cloud } as PluginsStart;
 
-    return { params, core: coreStart, plugins, getIsSidebarEnabled: () => this.isSidebarEnabled };
+    return { params, core: coreStart, plugins, isSidebarEnabled: this.isSidebarEnabled };
   }
 
   private getPluginData() {

--- a/x-pack/plugins/serverless_search/.gitignore
+++ b/x-pack/plugins/serverless_search/.gitignore
@@ -1,0 +1,2 @@
+/build
+/target

--- a/x-pack/plugins/serverless_search/.i18nrc.json
+++ b/x-pack/plugins/serverless_search/.i18nrc.json
@@ -1,0 +1,9 @@
+{
+  "prefix": "serverlessSearch",
+  "paths": {
+    "serverlessSearch": "."
+  },
+  "translations": [
+    "translations/ja-JP.json"
+  ]
+}

--- a/x-pack/plugins/serverless_search/README.md
+++ b/x-pack/plugins/serverless_search/README.md
@@ -1,0 +1,3 @@
+# serverlessSearch
+
+A witty, fitting description to come.

--- a/x-pack/plugins/serverless_search/common/index.ts
+++ b/x-pack/plugins/serverless_search/common/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const PLUGIN_ID = 'serverlessSearch';
+export const PLUGIN_NAME = 'serverlessSearch';

--- a/x-pack/plugins/serverless_search/kibana.jsonc
+++ b/x-pack/plugins/serverless_search/kibana.jsonc
@@ -1,0 +1,23 @@
+{
+  "type": "plugin",
+  "id": "@kbn/serverless-search",
+  "owner": "@elastic/appex-sharedux",
+  "description": "Serverless customizations for search.",
+  "plugin": {
+    "id": "serverlessSearch",
+    "server": true,
+    "browser": true,
+    "configPath": [
+      "xpack",
+      "serverless",
+      "search"
+    ],
+    "requiredPlugins": [
+      "serverless",
+      "enterpriseSearch",
+      "management"
+    ],
+    "optionalPlugins": [],
+    "requiredBundles": []
+  }
+}

--- a/x-pack/plugins/serverless_search/package.json
+++ b/x-pack/plugins/serverless_search/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@kbn/serverless-search",
+  "version": "1.0.0",
+  "license": "Elastic License 2.0",
+  "private": true,
+  "scripts": {
+    "build": "yarn plugin-helpers build",
+    "plugin-helpers": "node ../../../scripts/plugin_helpers",
+    "kbn": "node ../../../scripts/kbn"
+  }
+}

--- a/x-pack/plugins/serverless_search/public/index.ts
+++ b/x-pack/plugins/serverless_search/public/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ServerlessSearchPlugin } from './plugin';
+
+// This exports static code and TypeScript types,
+// as well as, Kibana Platform `plugin()` initializer.
+export function plugin() {
+  return new ServerlessSearchPlugin();
+}
+
+export type { ServerlessSearchPluginSetup, ServerlessSearchPluginStart } from './types';

--- a/x-pack/plugins/serverless_search/public/layout/nav.tsx
+++ b/x-pack/plugins/serverless_search/public/layout/nav.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiCollapsibleNavGroup, EuiListGroup } from '@elastic/eui';
+import { ApplicationStart, HttpSetup } from '@kbn/core/public';
+
+export interface ServerlessSearchCollapsibleNavigationProps {
+  http: HttpSetup;
+  navigateToUrl: ApplicationStart['navigateToUrl'];
+}
+
+export const ServerlessSearchCollapsibleNavigation = ({
+  http,
+  navigateToUrl,
+}: ServerlessSearchCollapsibleNavigationProps) => {
+  const navigateTo = (url: string) => () => {
+    navigateToUrl(http.basePath.prepend(url));
+  };
+  const navItems = [
+    {
+      label: 'Overview',
+      onClick: navigateTo('/app/enterprise_search/overview'),
+    },
+    {
+      label: 'Indices',
+      onClick: navigateTo('/app/enterprise_search/content/search_indices'),
+    },
+    {
+      label: 'Engines',
+      onClick: navigateTo('/app/enterprise_search/content/engines'),
+    },
+    {
+      label: 'API keys',
+      onClick: navigateTo('/app/management/security/api_keys'),
+    },
+    {
+      label: 'Ingest pipelines',
+      onClick: navigateTo('/app/management/ingest/ingest_pipelines'),
+    },
+  ];
+
+  return (
+    <>
+      <EuiCollapsibleNavGroup title="Search" iconType="logoEnterpriseSearch" isCollapsible={false}>
+        <EuiListGroup listItems={navItems} />
+      </EuiCollapsibleNavGroup>
+    </>
+  );
+};

--- a/x-pack/plugins/serverless_search/public/plugin.tsx
+++ b/x-pack/plugins/serverless_search/public/plugin.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
+import {
+  ServerlessSearchPluginSetup,
+  ServerlessSearchPluginSetupDependencies,
+  ServerlessSearchPluginStart,
+  ServerlessSearchPluginStartDependencies,
+} from './types';
+
+import { ServerlessSearchCollapsibleNavigation } from './layout/nav';
+
+export class ServerlessSearchPlugin
+  implements Plugin<ServerlessSearchPluginSetup, ServerlessSearchPluginStart>
+{
+  public setup(
+    _core: CoreSetup,
+    setupDeps: ServerlessSearchPluginSetupDependencies
+  ): ServerlessSearchPluginSetup {
+    setupDeps.enterpriseSearch.navigation.setIsSidebarEnabled(false);
+    setupDeps.management.setIsSidebarEnabled(false);
+    return {};
+  }
+
+  public start(
+    core: CoreStart,
+    { serverless }: ServerlessSearchPluginStartDependencies
+  ): ServerlessSearchPluginStart {
+    serverless.setServerlessNavigation(
+      <ServerlessSearchCollapsibleNavigation
+        http={core.http}
+        navigateToUrl={core.application.navigateToUrl}
+      />
+    );
+    return {};
+  }
+
+  public stop() {}
+}

--- a/x-pack/plugins/serverless_search/public/types.ts
+++ b/x-pack/plugins/serverless_search/public/types.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverless/public';
+import { ManagementSetup, ManagementStart } from '@kbn/management-plugin/public';
+import {
+  EnterpriseSearchPublicSetup,
+  EnterpriseSearchPublicStart,
+} from '@kbn/enterprise-search-plugin/public';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ServerlessSearchPluginSetup {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ServerlessSearchPluginStart {}
+
+export interface ServerlessSearchPluginSetupDependencies {
+  enterpriseSearch: EnterpriseSearchPublicSetup;
+  management: ManagementSetup;
+  serverless: ServerlessPluginSetup;
+}
+
+export interface ServerlessSearchPluginStartDependencies {
+  enterpriseSearch: EnterpriseSearchPublicStart;
+  management: ManagementStart;
+  serverless: ServerlessPluginStart;
+}

--- a/x-pack/plugins/serverless_search/server/config.ts
+++ b/x-pack/plugins/serverless_search/server/config.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema, TypeOf } from '@kbn/config-schema';
+import { PluginConfigDescriptor } from '@kbn/core/server';
+
+export * from './types';
+
+const configSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: false }),
+});
+
+type ConfigType = TypeOf<typeof configSchema>;
+
+export const config: PluginConfigDescriptor<ConfigType> = {
+  schema: configSchema,
+};
+
+export type ServerlessSearchConfig = TypeOf<typeof configSchema>;

--- a/x-pack/plugins/serverless_search/server/index.ts
+++ b/x-pack/plugins/serverless_search/server/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PluginInitializerContext } from '@kbn/core/server';
+
+import { ServerlessSearchPlugin } from './plugin';
+export { config } from './config';
+
+//  This exports static code and TypeScript types,
+//  as well as, Kibana Platform `plugin()` initializer.
+
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new ServerlessSearchPlugin(initializerContext);
+}
+
+export type { ServerlessSearchPluginSetup, ServerlessSearchPluginStart } from './types';

--- a/x-pack/plugins/serverless_search/server/plugin.ts
+++ b/x-pack/plugins/serverless_search/server/plugin.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PluginInitializerContext, Plugin } from '@kbn/core/server';
+
+import { ServerlessSearchPluginSetup, ServerlessSearchPluginStart } from './types';
+
+export class ServerlessSearchPlugin
+  implements Plugin<ServerlessSearchPluginSetup, ServerlessSearchPluginStart>
+{
+  constructor(_initializerContext: PluginInitializerContext) {}
+
+  public setup() {
+    return {};
+  }
+
+  public start() {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/x-pack/plugins/serverless_search/server/types.ts
+++ b/x-pack/plugins/serverless_search/server/types.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ServerlessSearchPluginSetup {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ServerlessSearchPluginStart {}

--- a/x-pack/plugins/serverless_search/tsconfig.json
+++ b/x-pack/plugins/serverless_search/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types"
+  },
+  "include": [
+    "index.ts",
+    "common/**/*.ts",
+    "public/**/*.ts",
+    "public/**/*.tsx",
+    "server/**/*.ts",
+    "../../../typings/**/*"
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/core",
+    "@kbn/config-schema",
+    "@kbn/enterprise-search-plugin",
+    "@kbn/management-plugin",
+    "@kbn/serverless",
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4917,6 +4917,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/serverless-search@link:x-pack/plugins/serverless_search":
+  version "0.0.0"
+  uid ""
+
 "@kbn/serverless-security@link:x-pack/plugins/serverless_security":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
## Summary

- Update `enterprise_search` plugin to allow hiding page sidebar (`solutionnav`)
- Update `management` plugin to allow hiding page sidebar (`solutionnav`)
- `enterprise_search` hide App Search & Workplace Search for Serverless
- `enterprise_search` hide Engines cta on index page when App Search is unavailable
- Created `serverless_search` plugin with a POC side navigation

## Screenshots

![image](https://user-images.githubusercontent.com/1972968/222463544-4bfc51e9-3cfc-41ae-8b6c-758acf320f90.png)


## Notes

Right now the enterprise_search plugin is still relying on `ent-search` to be available. Which it will not be for Serverless, we will work to remove this dependency for the pages that will be used by `serverless_search`. 

Nav item labels do not have translations.
Nav items do not show active item, need history in the `serverless_search` plugin for this.