### PR TITLE
[Serverless] Disable Management team plugins

### DIFF
--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -3,7 +3,6 @@ xpack.canvas.enabled: false
 xpack.cloudSecurityPosture.enabled: false
 xpack.reporting.enabled: false
 xpack.securitySolution.enabled: false
-xpack.watcher.enabled: false
 
 xpack.serverless.observability.enabled: true
 

--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -3,7 +3,6 @@ xpack.canvas.enabled: false
 xpack.observability.enabled: false
 xpack.reporting.enabled: false
 xpack.uptime.enabled: false
-xpack.watcher.enabled: false
 
 xpack.serverless.security.enabled: true
 

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -8,3 +8,4 @@ xpack.watcher.enabled: false
 xpack.ccr.enabled: false
 xpack.ilm.enabled: false
 xpack.remote_clusters.enabled: false
+xpack.snapshot_restore.enabled: false

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -5,3 +5,4 @@ xpack.fleet.enableExperimental: ['fleetServerStandalone']
 xpack.upgrade_assistant.enabled: false
 xpack.rollup.enabled: false
 xpack.watcher.enabled: false
+xpack.ccr.enabled: false

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -1,3 +1,5 @@
 
 xpack.serverless.plugin.enabled: true
 xpack.fleet.enableExperimental: ['fleetServerStandalone']
+
+xpack.upgrade_assistant.enabled: false

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -4,3 +4,4 @@ xpack.fleet.enableExperimental: ['fleetServerStandalone']
 
 xpack.upgrade_assistant.enabled: false
 xpack.rollup.enabled: false
+xpack.watcher.enabled: false

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -2,6 +2,7 @@
 xpack.serverless.plugin.enabled: true
 xpack.fleet.enableExperimental: ['fleetServerStandalone']
 
+# Management team plugins
 xpack.upgrade_assistant.enabled: false
 xpack.rollup.enabled: false
 xpack.watcher.enabled: false

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -7,3 +7,4 @@ xpack.rollup.enabled: false
 xpack.watcher.enabled: false
 xpack.ccr.enabled: false
 xpack.ilm.enabled: false
+xpack.remote_clusters.enabled: false

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -3,3 +3,4 @@ xpack.serverless.plugin.enabled: true
 xpack.fleet.enableExperimental: ['fleetServerStandalone']
 
 xpack.upgrade_assistant.enabled: false
+xpack.rollup.enabled: false

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -6,3 +6,4 @@ xpack.upgrade_assistant.enabled: false
 xpack.rollup.enabled: false
 xpack.watcher.enabled: false
 xpack.ccr.enabled: false
+xpack.ilm.enabled: false

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -9,3 +9,4 @@ xpack.ccr.enabled: false
 xpack.ilm.enabled: false
 xpack.remote_clusters.enabled: false
 xpack.snapshot_restore.enabled: false
+xpack.license_management.enabled: false

--- a/x-pack/plugins/cross_cluster_replication/server/config.ts
+++ b/x-pack/plugins/cross_cluster_replication/server/config.ts
@@ -22,6 +22,11 @@ const schemaLatest = schema.object(
     ui: schema.object({
       enabled: schema.boolean({ defaultValue: true }),
     }),
+    /**
+     * Disables the plugin.
+     * Added back in 8.8.
+     */
+    enabled: schema.boolean({ defaultValue: true }),
   },
   { defaultValue: undefined }
 );

--- a/x-pack/plugins/index_lifecycle_management/server/config.ts
+++ b/x-pack/plugins/index_lifecycle_management/server/config.ts
@@ -24,6 +24,11 @@ const schemaLatest = schema.object(
     }),
     // Cloud requires the ability to hide internal node attributes from users.
     filteredNodeAttributes: schema.arrayOf(schema.string(), { defaultValue: [] }),
+    /**
+     * Disables the plugin.
+     * Added back in 8.8.
+     */
+    enabled: schema.boolean({ defaultValue: true }),
   },
   { defaultValue: undefined }
 );

--- a/x-pack/plugins/license_management/server/config.ts
+++ b/x-pack/plugins/license_management/server/config.ts
@@ -22,6 +22,11 @@ const schemaLatest = schema.object(
     ui: schema.object({
       enabled: schema.boolean({ defaultValue: true }),
     }),
+    /**
+     * Disables the plugin.
+     * Added back in 8.8.
+     */
+    enabled: schema.boolean({ defaultValue: true }),
   },
   { defaultValue: undefined }
 );

--- a/x-pack/plugins/remote_clusters/server/config.ts
+++ b/x-pack/plugins/remote_clusters/server/config.ts
@@ -22,6 +22,11 @@ const schemaLatest = schema.object(
     ui: schema.object({
       enabled: schema.boolean({ defaultValue: true }),
     }),
+    /**
+     * Disables the plugin.
+     * Added back in 8.8.
+     */
+    enabled: schema.boolean({ defaultValue: true }),
   },
   { defaultValue: undefined }
 );

--- a/x-pack/plugins/rollup/server/config.ts
+++ b/x-pack/plugins/rollup/server/config.ts
@@ -22,6 +22,11 @@ const schemaLatest = schema.object(
     ui: schema.object({
       enabled: schema.boolean({ defaultValue: true }),
     }),
+    /**
+     * Disables the plugin.
+     * Added back in 8.8.
+     */
+    enabled: schema.boolean({ defaultValue: true }),
   },
   { defaultValue: undefined }
 );

--- a/x-pack/plugins/snapshot_restore/server/config.ts
+++ b/x-pack/plugins/snapshot_restore/server/config.ts
@@ -25,6 +25,11 @@ const schemaLatest = schema.object(
     slm_ui: schema.object({
       enabled: schema.boolean({ defaultValue: true }),
     }),
+    /**
+     * Disables the plugin.
+     * Added back in 8.8.
+     */
+    enabled: schema.boolean({ defaultValue: true }),
   },
   { defaultValue: undefined }
 );

--- a/x-pack/plugins/upgrade_assistant/server/config.ts
+++ b/x-pack/plugins/upgrade_assistant/server/config.ts
@@ -12,6 +12,11 @@ import { PluginConfigDescriptor } from '@kbn/core/server';
 // even for minor releases.
 // -------------------------------
 const configSchema = schema.object({
+  /**
+   * Disables the plugin.
+   */
+  enabled: schema.boolean({ defaultValue: true }),
+
   featureSet: schema.object({
     /**
      * Ml Snapshot should only be enabled for major version upgrades. Currently this
@@ -39,6 +44,9 @@ const configSchema = schema.object({
      */
     reindexCorrectiveActions: schema.boolean({ defaultValue: false }),
   }),
+  /**
+   * This config allows to hide the UI without disabling the plugin.
+   */
   ui: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
   }),


### PR DESCRIPTION
## Summary
This PR makes following plugins disable-able for serverless
- Upgrade Assistant
- Rollup Jobs
- Watcher
- CCR
- ILM
- Remote Clusters
- Snapshot & Restore
- License Management

