### PR TITLE
[Storybook] Publish registry.js for docs-site embeds and apply bucket CORS

### DIFF
--- a/.buildkite/scripts/steps/storybooks/build_and_upload.ts
+++ b/.buildkite/scripts/steps/storybooks/build_and_upload.ts
@@ -128,11 +128,38 @@ const upload = () => {
       process.cwd(),
       path.join(getKibanaDir(), '.buildkite', 'scripts', 'common', 'activate_service_account.sh')
     );
+    const corsConfig = path.join(
+      getKibanaDir(),
+      '.buildkite',
+      'scripts',
+      'steps',
+      'storybooks',
+      'cors.json'
+    );
     exec(`
       ${activateScript} gs://ci-artifacts.kibana.dev
       gcloud storage cp --cache-control="no-cache, max-age=0, no-transform" --gzip-local=js,css,html,json,map,txt,svg --recursive --no-user-output-enabled '*' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/'
       gcloud storage cp --cache-control="no-cache, max-age=0, no-transform" --gzip-local=html --no-user-output-enabled 'index.html' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/latest/'
     `);
+
+    // CORS is bucket-wide in GCS. The Elastic docs site loads registry.js as
+    // a module script and fetches index.json, both of which require CORS on
+    // the response. Re-applying the same config on every upload is a no-op.
+    // Tolerated to fail loudly (without breaking the storybook publish) in
+    // case the CI service account lacks storage.buckets.update — SRE can
+    // then apply cors.json once via `gcloud storage buckets update`.
+    console.log('--- Applying CORS policy to ci-artifacts.kibana.dev');
+    try {
+      execSync(
+        `gcloud storage buckets update gs://ci-artifacts.kibana.dev --cors-file="${corsConfig}"`,
+        { stdio: 'inherit' }
+      );
+    } catch (err) {
+      console.warn(
+        `Failed to apply CORS to gs://ci-artifacts.kibana.dev (likely missing storage.buckets.update on the upload service account). Storybook embeds from codex.elastic.dev / docs-v3-preview.elastic.dev will fail until SRE applies ${corsConfig} to the bucket.`
+      );
+      console.warn(err);
+    }
 
     if (process.env.BUILDKITE_PULL_REQUEST && process.env.BUILDKITE_PULL_REQUEST !== 'false') {
       exec(

--- a/.buildkite/scripts/steps/storybooks/cors.json
+++ b/.buildkite/scripts/steps/storybooks/cors.json
@@ -1,0 +1,19 @@
+[
+  {
+    "origin": [
+      "https://codex.elastic.dev",
+      "https://docs-v3-preview.elastic.dev",
+      "https://docs.elastic.co",
+      "https://www.elastic.co"
+    ],
+    "method": ["GET", "HEAD", "OPTIONS"],
+    "responseHeader": [
+      "Content-Type",
+      "Content-Encoding",
+      "Cache-Control",
+      "ETag",
+      "Range"
+    ],
+    "maxAgeSeconds": 3600
+  }
+]

--- a/src/platform/packages/shared/kbn-storybook/src/lib/default_config.ts
+++ b/src/platform/packages/shared/kbn-storybook/src/lib/default_config.ts
@@ -243,6 +243,9 @@ export const defaultConfig: StorybookConfig = {
     UiSharedDepsNpm.distDir,
     UiSharedDepsSrc.distDir,
     `${REPO_ROOT}/target/build/src/platform/packages/shared/kbn-monaco/target_workers`,
+    // Publishes registry.js (mountStory/unmountStory) at the build root so the
+    // Elastic docs site can embed stories from this static build.
+    `${REPO_ROOT}/src/platform/packages/shared/kbn-storybook/static`,
     {
       from: `${REPO_ROOT}/src/platform/plugins/shared/kibana_react/public/assets`,
       to: 'plugins/kibanaReact/assets',

--- a/src/platform/packages/shared/kbn-storybook/static/registry.js
+++ b/src/platform/packages/shared/kbn-storybook/static/registry.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+// Public embed surface for Kibana Storybook static builds.
+// Consumed by the Elastic docs site to embed individual stories without
+// pulling Storybook's preview bundle into the host page. Each story renders
+// inside an iframe pointing at this build's `iframe.html`, which sandboxes
+// EUI styling/globals from the host and avoids cross-origin fetches of story
+// JS — only this module itself requires CORS to be loaded by the host.
+
+const baseUrl = new URL('.', import.meta.url);
+const mounts = new WeakMap();
+
+const resolveHost = (target) => {
+  if (typeof target === 'string') {
+    const el = document.querySelector(target);
+    if (!el) {
+      throw new Error(`@kbn/storybook registry: no element matches "${target}"`);
+    }
+    return el;
+  }
+  if (!(target instanceof Element)) {
+    throw new TypeError('@kbn/storybook registry: target must be a selector or Element');
+  }
+  return target;
+};
+
+export const mountStory = (target, storyId, options = {}) => {
+  if (!storyId || typeof storyId !== 'string') {
+    throw new TypeError('@kbn/storybook registry: storyId must be a non-empty string');
+  }
+
+  const host = resolveHost(target);
+  unmountStory(host);
+
+  const params = new URLSearchParams({ id: storyId, viewMode: options.viewMode ?? 'story' });
+  if (options.globals) params.set('globals', options.globals);
+  if (options.args) params.set('args', options.args);
+
+  const iframe = document.createElement('iframe');
+  iframe.src = new URL(`iframe.html?${params.toString()}`, baseUrl).href;
+  iframe.title = options.title ?? `Storybook: ${storyId}`;
+  iframe.loading = options.loading ?? 'lazy';
+  iframe.style.border = '0';
+  iframe.style.width = options.width ?? '100%';
+  iframe.style.height = options.height ?? '500px';
+  iframe.style.display = 'block';
+
+  host.appendChild(iframe);
+  mounts.set(host, iframe);
+  return iframe;
+};
+
+export const unmountStory = (target) => {
+  const host = resolveHost(target);
+  const iframe = mounts.get(host);
+  if (iframe?.parentNode === host) {
+    host.removeChild(iframe);
+  }
+  mounts.delete(host);
+};
+
+export default { mountStory, unmountStory };


### PR DESCRIPTION
## Summary

The Elastic docs site embeds individual Kibana Storybook stories by loading `mountStory` / `unmountStory` from `registry.js` at the root of each static build (alongside `iframe.html`). Today the build doesn't emit that file and the GCS bucket has no CORS policy, so cross-origin loads from `codex.elastic.dev` and `docs-v3-preview.elastic.dev` fail.

### Build / artifact

- **New `static/registry.js` in `@kbn/storybook`** — ES module exporting `mountStory(target, storyId, options)` and `unmountStory(target)`. Renders the story inside an iframe pointing at the sibling `iframe.html?id=<storyId>`. Iframes sandbox EUI styling/globals from the host docs page and avoid cross-origin fetches of story bundles, so only `registry.js` itself needs CORS.
- **Wired into `defaultConfig.staticDirs`** — every per-plugin storybook inherits `defaultConfig`, so all ~80 builds emit `registry.js` at the build root. After this lands, URLs like `https://ci-artifacts.kibana.dev/storybooks/main/shared_ux/registry.js` will resolve.

### CORS on `gs://ci-artifacts.kibana.dev`

- **New `.buildkite/scripts/steps/storybooks/cors.json`** — allows `GET / HEAD / OPTIONS` from `codex.elastic.dev`, `docs-v3-preview.elastic.dev`, `docs.elastic.co`, and `www.elastic.co`.
- **Applied during upload** — `gcloud storage buckets update gs://ci-artifacts.kibana.dev --cors-file=cors.json` runs after each upload (idempotent).
- GCS CORS is **bucket-wide, not per-object**, so this affects every artifact in `ci-artifacts.kibana.dev`. The scope of access granted (read-only, four Elastic-controlled origins) is conservative.
- The upload service account `kibana-ci-access-artifacts@elastic-kibana-ci.iam.gserviceaccount.com` may not have `storage.buckets.update`. The step tolerates failure and prints a clear message so SRE can apply `cors.json` once via `gcloud storage buckets update` if the in-CI call is denied.

## Embed contract (for the docs side)

```js
import { mountStory, unmountStory } from 'https://ci-artifacts.kibana.dev/storybooks/main/<alias>/registry.js';

mountStory(document.querySelector('#embed'), 'no-data-card--card', {
  height: '400px',
});
```

`options` supports `width`, `height`, `title`, `loading`, `viewMode`, `globals`, `args`.

## Test plan

- [ ] Run the storybooks pipeline against this branch and confirm `registry.js` appears at `https://ci-artifacts.kibana.dev/storybooks/pr-<N>/shared_ux/registry.js` (and for at least one other alias).
- [ ] From a page on `codex.elastic.dev` (or a local origin allow-listed in `cors.json`), import `registry.js` and call `mountStory(el, 'no-data-card--card')` against the `shared_ux` build; confirm the story renders inside an iframe.
- [ ] Confirm the `Applying CORS policy` step in the Buildkite log either succeeds or prints the documented warning (and the publish still completes).
- [ ] If the upload service account is denied `storage.buckets.update`, file an SRE request to apply `.buildkite/scripts/steps/storybooks/cors.json` to the bucket once.

---
_Generated by [Claude Code](https://claude.ai/code/session_013KcqAKgYYFf5Jq2Gc7wovC)_